### PR TITLE
Correct ifNotFloat

### DIFF
--- a/src/Validate.elm
+++ b/src/Validate.elm
@@ -209,7 +209,7 @@ ifNothing subjectToMaybe error =
 -}
 ifNotFloat : (subject -> String) -> error -> Validator error subject
 ifNotFloat subjectToString error =
-    ifTrue (\subject -> isFloat (subjectToString subject)) error
+    ifFalse (\subject -> isFloat (subjectToString subject)) error
 
 
 {-| Return an error if an email address is malformed.


### PR DESCRIPTION
Changed ifNotFloat to create an error in case the string cannot be parsed to a float.
Previously it was creating the error if the string could be parsed to a float.